### PR TITLE
Implemented a RefreshNow function for the cache. Bug fixes for except…

### DIFF
--- a/secretcache/cache.go
+++ b/secretcache/cache.go
@@ -135,3 +135,10 @@ func (c *Cache) GetSecretBinaryWithStage(secretId string, versionStage string) (
 
 	return getSecretValueOutput.SecretBinary, nil
 }
+
+// RefreshNow forces a refresh on a cached secret state.
+// Returns a boolean to indicate refresh success and an error if one occurred.
+func (c *Cache) RefreshNow(secretId string) (bool, error) {
+	secretCacheItem := c.getCachedSecret(secretId)
+	return secretCacheItem.refreshNow()
+}

--- a/secretcache/cacheObject.go
+++ b/secretcache/cacheObject.go
@@ -53,9 +53,5 @@ func (o *cacheObject) isRefreshNeeded() bool {
 		return false
 	}
 
-	if o.nextRetryTime == 0 {
-		return true
-	}
-
 	return o.nextRetryTime <= time.Now().UnixNano()
 }

--- a/secretcache/cacheVersion.go
+++ b/secretcache/cacheVersion.go
@@ -59,7 +59,7 @@ func (cv *cacheVersion) refresh() {
 		cv.err = err
 		delay := exceptionRetryDelayBase * math.Pow(exceptionRetryGrowthFactor, float64(cv.errorCount))
 		delay = math.Min(delay, exceptionRetryDelayMax)
-		delayDuration := time.Nanosecond * time.Duration(delay)
+		delayDuration := time.Millisecond * time.Duration(delay)
 		cv.nextRetryTime = time.Now().Add(delayDuration).UnixNano()
 		return
 	}


### PR DESCRIPTION
…ion retry delay, and concurrent mutation test. Each cache item now uses its own seeded rand.

*Issue #, if available:* N/A

*Description of changes:*
Implemented a RefreshNow function for the cache. Bug fixes for exception retry delay, and concurrent mutation test. Each cache item now uses its own seeded rand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
