### PR TITLE
Add config option to Disable refreshing of cached secrets completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ func main() {
 
 ### Cache Configuration
 * `MaxCacheSize int` The maximum number of cached secrets to maintain before evicting secrets that have not been accessed recently.
-* `CacheItemTTL int64` The number of nanoseconds that a cached item is considered valid before requiring a refresh of the secret state.  Items that have exceeded this TTL will be refreshed synchronously when requesting the secret value.  If the synchronous refresh failed, the stale secret will be returned.
+* `CacheItemTTL int64` The number of nanoseconds that a cached item is considered valid before requiring a refresh of the secret state.  Items that have exceeded this TTL will be refreshed synchronously when requesting the secret value.  If the synchronous refresh failed, the stale secret will be returned. This config is not applicable if `DisableRefresh` is set to `true`.
+* `DisableRefresh bool` Disable refreshing of cached items
 * `VersionStage string` The version stage that will be used when requesting the secret values for this cache.
 * `Hook CacheHook` Used to hook in-memory cache updates.
 
@@ -68,6 +69,7 @@ func main() {
 		MaxCacheSize: secretcache.DefaultMaxCacheSize + 10,
 		VersionStage: secretcache.DefaultVersionStage,
 		CacheItemTTL: secretcache.DefaultCacheItemTTL,
+		DisableRefresh: false,
 	}
 	
 	//Instantiate the cache

--- a/secretcache/cacheConfig.go
+++ b/secretcache/cacheConfig.go
@@ -39,4 +39,7 @@ type CacheConfig struct {
 
 	//Used to hook in-memory cache updates.
 	Hook CacheHook
+
+	//Disable refreshing of Cache entries
+	DisableRefresh bool
 }

--- a/secretcache/cacheConfig.go
+++ b/secretcache/cacheConfig.go
@@ -31,6 +31,7 @@ type CacheConfig struct {
 	// requiring a refresh of the secret state.  Items that have exceeded this
 	// TTL will be refreshed synchronously when requesting the secret value.  If
 	// the synchronous refresh failed, the stale secret will be returned.
+	// This config is not used if DisableRefresh is set to true
 	CacheItemTTL int64
 
 	//The version stage that will be used when requesting the secret values for

--- a/secretcache/cacheItem.go
+++ b/secretcache/cacheItem.go
@@ -48,6 +48,10 @@ func newSecretCacheItem(config CacheConfig, client secretsmanageriface.SecretsMa
 
 // isRefreshNeeded determines if the cached item should be refreshed.
 func (ci *secretCacheItem) isRefreshNeeded() bool {
+
+	if ci.config.DisableRefresh {
+		return false
+	}
 	if ci.cacheObject.isRefreshNeeded() {
 		return true
 	}

--- a/secretcache/cacheObject.go
+++ b/secretcache/cacheObject.go
@@ -45,6 +45,9 @@ type cacheObject struct {
 
 // isRefreshNeeded determines if the cached object should be refreshed.
 func (o *cacheObject) isRefreshNeeded() bool {
+	if o.config.DisableRefresh {
+		return false
+	}
 	if o.refreshNeeded {
 		return true
 	}

--- a/secretcache/cacheObjects_test.go
+++ b/secretcache/cacheObjects_test.go
@@ -102,3 +102,32 @@ func (d *dummyClient) DescribeSecretWithContext(context aws.Context, input *secr
 func getStrPtr(str string) *string {
 	return &str
 }
+
+func TestDisableRefresh(t *testing.T) {
+	obj := cacheObject{refreshNeeded: true, config: CacheConfig{DisableRefresh: true}}
+
+	if obj.isRefreshNeeded() {
+		t.Fatalf("Expected false  when config DisableRefresh is true")
+	}
+
+	if obj.isRefreshNeeded() {
+		t.Fatalf("Expected false when err is nil")
+	}
+
+	obj.err = errors.New("some dummy error")
+
+	if obj.isRefreshNeeded() {
+		t.Fatalf("Expected false  when config DisableRefresh is true")
+	}
+
+	obj.nextRetryTime = time.Now().Add(time.Hour * 1).UnixNano()
+
+	if obj.isRefreshNeeded() {
+		t.Fatalf("Expected false when config DisableRefresh is true")
+	}
+
+	obj.nextRetryTime = time.Now().Add(-(time.Hour * 1)).UnixNano()
+	if obj.isRefreshNeeded() {
+		t.Fatalf("Expected false when config DisableRefresh is true")
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add config option to disable refreshing of Cache items completely, once loaded same value will be returned

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
