### PR TITLE
fix(cache.go): correct typo from cache.go file comment as it should read "string" and not "sting"

### DIFF
--- a/secretcache/cache.go
+++ b/secretcache/cache.go
@@ -81,13 +81,13 @@ func (c *Cache) getCachedSecret(secretId string) *secretCacheItem {
 }
 
 // GetSecretString gets the secret string value from the cache for given secret id and a default version stage.
-// Returns the secret sting and an error if operation failed.
+// Returns the secret string and an error if operation failed.
 func (c *Cache) GetSecretString(secretId string) (string, error) {
 	return c.GetSecretStringWithStage(secretId, DefaultVersionStage)
 }
 
 // GetSecretStringWithStage gets the secret string value from the cache for given secret id and version stage.
-// Returns the secret sting and an error if operation failed.
+// Returns the secret string and an error if operation failed.
 func (c *Cache) GetSecretStringWithStage(secretId string, versionStage string) (string, error) {
 	secretCacheItem := c.getCachedSecret(secretId)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

correct typo from cache.go file comment as it should read "string" and not "sting"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
