### PR TITLE
Adding refreshNow functionality to the cache

### DIFF
--- a/secretcache/cache.go
+++ b/secretcache/cache.go
@@ -154,3 +154,13 @@ func (c *Cache) GetSecretBinaryWithStageWithContext(ctx context.Context, secretI
 
 	return getSecretValueOutput.SecretBinary, nil
 }
+
+// Method to force the refresh of a secret inside the cache
+func (c *Cache) RefreshNow(secretId string) {
+	c.RefreshNowWithContext(aws.BackgroundContext(), secretId)
+}
+
+func (c *Cache) RefreshNowWithContext(ctx context.Context, secretId string) {
+	secretCacheItem := c.getCachedSecret(secretId)
+	secretCacheItem.refreshNow(ctx)
+}

--- a/secretcache/cacheObject.go
+++ b/secretcache/cacheObject.go
@@ -24,6 +24,7 @@ const (
 	exceptionRetryDelayBase    = 1
 	exceptionRetryGrowthFactor = 2
 	exceptionRetryDelayMax     = 3600
+	forceRefreshJitterSleep    = 5000
 )
 
 // Base cache object for common properties.


### PR DESCRIPTION
*Issue #, if available:*
#72 

*Description of changes:*
Adding refreshNow functionality to allow the cached secret to be refreshed on demand


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
