### PR TITLE
Updating go.mod to include /v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/aws-secretsmanager-caching-go
+module github.com/aws/aws-secretsmanager-caching-go/v2
 
 go 1.20
 

--- a/scintegtests/integration_test.go
+++ b/scintegtests/integration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
+	"github.com/aws/aws-secretsmanager-caching-go/v2/secretcache"
 	"github.com/aws/smithy-go"
 )
 

--- a/secretcache/cacheHook_test.go
+++ b/secretcache/cacheHook_test.go
@@ -15,8 +15,9 @@ package secretcache_test
 
 import (
 	"bytes"
-	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
 	"testing"
+
+	"github.com/aws/aws-secretsmanager-caching-go/v2/secretcache"
 )
 
 type DummyCacheHook struct {

--- a/secretcache/cache_test.go
+++ b/secretcache/cache_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
+	"github.com/aws/aws-secretsmanager-caching-go/v2/secretcache"
 
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )

--- a/secretcache/mockClient_test.go
+++ b/secretcache/mockClient_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
+	"github.com/aws/aws-secretsmanager-caching-go/v2/secretcache"
 )
 
 // A struct to be used in unit tests as a mock Client


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding v2 to the path of the module as needed [here](https://go.dev/wiki/Modules#gomod:~:text=As%20a%20result%20of%20Semantic%20Import%20Versioning%2C%20code%20opting%20in%20to%20Go%20modules%20must%20comply%20with%20these%20rules%3A)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
